### PR TITLE
Cluster::initialize allows cluster name and cephx user to be specified

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,15 @@ Or install it yourself as:
     pool = cluster.pool("my-pool-xyz")
     pool.open
 
+    # CephRuby::Cluster.new currently accepts up to three setings.
+    # conf_file - path to your ceph.conf file (default: /etc/ceph/ceph.conf)
+    # options hash:
+    #   :user    - cephx user to authenticate against (default: client.admin)
+                     (would look for a keyring file at: '/etc/ceph/<cluster>.<user>.keyring')
+    #   :cluster - ceph cluster to connect to (default: ceph)
+
+    cluster = CephRuby::Cluster.new "/etc/ceph/us-east.conf", {cluster: 'us-east', user: 'client.amazing'}
+
     # simple example for using rados objects
     object = pool.rados_object("my-object-xyz")
     object.write(0, "This is a Test!")

--- a/lib/ceph-ruby/lib/rados.rb
+++ b/lib/ceph-ruby/lib/rados.rb
@@ -12,6 +12,7 @@ module CephRuby
       attach_function 'rados_version', [:pointer, :pointer, :pointer], :void
 
       attach_function 'rados_create', [:pointer, :string], :int
+      attach_function 'rados_create2', [:pointer, :string, :string, :int], :int
       attach_function 'rados_connect', [:pointer], :int
       attach_function 'rados_conf_read_file', [:pointer, :string], :int
       attach_function 'rados_shutdown', [:pointer], :void

--- a/lib/ceph-ruby/version.rb
+++ b/lib/ceph-ruby/version.rb
@@ -1,3 +1,3 @@
 module CephRuby
-  VERSION = "1.1"
+  VERSION = "1.2"
 end


### PR DESCRIPTION
Updated the cluster initialize function to use rados_create2 and added options hash for user and cluster details to be provided.
