### PR TITLE
Integration specs with RSpec

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,1 @@
+--require spec_helper

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+sudo: required
+
+language: ruby
+
+services:
+  - docker
+
+before_install:
+  - docker-compose build
+
+script:
+  - docker-compose run app rspec

--- a/README.md
+++ b/README.md
@@ -2,6 +2,19 @@
 
 Easy management of Ceph Distributed Storage System (rbd, images, rados objects) using ruby.
 
+## Development
+
+```
+docker-compose build
+docker-compose run app # Will open a console for you to work with
+```
+
+## Tests
+
+```
+docker-compose build
+docker-compose run app rspec
+```
 
 ## Installation
 

--- a/ceph-ruby.gemspec
+++ b/ceph-ruby.gemspec
@@ -20,4 +20,6 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency('ffi', '~> 1.1.5')
   gem.add_dependency('activesupport', '>= 3.0.0')
+  gem.add_development_dependency('rspec')
+  gem.add_development_dependency('pry')
 end

--- a/lib/ceph-ruby/rados_object.rb
+++ b/lib/ceph-ruby/rados_object.rb
@@ -22,6 +22,7 @@ module CephRuby
       size = data.bytesize
       log("write offset #{offset}, size #{size}")
       ret = Lib::Rados.rados_write(pool.handle, name, data, size, offset)
+
       raise SystemCallError.new("write of #{size} bytes to '#{name}' at #{offset} failed", -ret) if ret < 0
       raise Errno::EIO.new("wrote only #{ret} of #{size} bytes to '#{name}' at #{offset}") if ret < size
     end

--- a/spec/features/pool_spec.rb
+++ b/spec/features/pool_spec.rb
@@ -1,0 +1,33 @@
+require 'spec_helper'
+
+RSpec.describe CephRuby::Pool do
+  let(:cluster)   { CephRuby::Cluster.new(username: 'admin') }
+  let(:pool)      { described_class.new(cluster, pool_name) }
+
+  around do |example|
+    CephCommands.create_pool(pool_name)
+    pool.open
+
+    example.run
+
+    pool.close
+    CephCommands.delete_pool(pool_name)
+    cluster.close
+  end
+
+  describe '#list' do
+    let(:pool_name) { 'my-pool-for-testing' }
+
+    context 'no images' do
+      it { expect(pool.list).to be_empty }
+    end
+
+    context 'one image' do
+      let!(:image_name) { 'my-image' }
+
+      before { CephCommands.create_image(pool_name, image_name) }
+
+      it { expect(pool.list).to match_array('my-image') }
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,16 @@
+require 'ceph-ruby'
+require 'pry'
+
+Dir['./spec/support/**/*.rb'].sort.each { |f| require f }
+
+RSpec.configure do |config|
+  config.expect_with :rspec do |expectations|
+    expectations.include_chain_clauses_in_custom_matcher_descriptions = true
+  end
+
+  config.mock_with :rspec do |mocks|
+    mocks.verify_partial_doubles = true
+  end
+
+  config.shared_context_metadata_behavior = :apply_to_host_groups
+end

--- a/spec/support/ceph.rb
+++ b/spec/support/ceph.rb
@@ -1,0 +1,15 @@
+class CephCommands
+  class << self
+    def create_pool(pool_name, size = 1)
+      `ceph osd pool create #{pool_name} #{size}`
+    end
+
+    def delete_pool(pool_name)
+      `ceph osd pool delete #{pool_name} #{pool_name} --yes-i-really-really-mean-it`
+    end
+
+    def create_image(pool_name, image_name)
+      `rbd -p #{pool_name} create #{image_name} --size 128`
+    end
+  end
+end


### PR DESCRIPTION
### Background

Follow-up issue of #14. 

### What's new?

Adds integration tests for ceph-ruby (launched in Travis CI via docker-compose - see #14).

### Live demo

We have configured it for our fork in Travis: https://travis-ci.org/ninech/ceph-ruby/builds/303440767